### PR TITLE
Add more uniqueness to keys in multi tenant environment

### DIFF
--- a/src/AccessTokenManager.php
+++ b/src/AccessTokenManager.php
@@ -45,7 +45,7 @@ class AccessTokenManager
 
     public function getAccessToken(): string
     {
-        $cacheKey = 'logic4:access_token:'.base64_encode($this->makeClientId());
+        $cacheKey = 'logic4:access_token:'.base64_encode($this->makeClientId().':'.$this->makeScope());
 
         if ($this->cache->has($cacheKey)) {
             return $this->cache->get($cacheKey);

--- a/tests/Integration/AccessTokenManagerTest.php
+++ b/tests/Integration/AccessTokenManagerTest.php
@@ -45,7 +45,7 @@ final class AccessTokenManagerTest extends TestCase
             $mock->shouldReceive('has')
                 ->once()
                 ->withArgs(function (string $key): bool {
-                    static::assertSame('logic4:access_token:'.base64_encode('publicKey companyKey user__name_(2)'), $key);
+                    static::assertSame('logic4:access_token:'.base64_encode('publicKey companyKey user__name_(2):api administration.administration-1'), $key);
 
                     return true;
                 })
@@ -54,7 +54,7 @@ final class AccessTokenManagerTest extends TestCase
             $mock->shouldReceive('set')
                 ->once()
                 ->withArgs(function (string $key, string $value, int $ttl): bool {
-                    static::assertSame('logic4:access_token:'.base64_encode('publicKey companyKey user__name_(2)'), $key);
+                    static::assertSame('logic4:access_token:'.base64_encode('publicKey companyKey user__name_(2):api administration.administration-1'), $key);
                     static::assertSame('the-new-access-token', $value);
                     static::assertSame(3600, $ttl);
 
@@ -99,7 +99,7 @@ final class AccessTokenManagerTest extends TestCase
             $mock->shouldReceive('has')
                 ->once()
                 ->withArgs(function (string $key): bool {
-                    static::assertSame('logic4:access_token:'.base64_encode('publicKey companyKey user__name_(2)'), $key);
+                    static::assertSame('logic4:access_token:'.base64_encode('publicKey companyKey user__name_(2):api administration.administration-1'), $key);
 
                     return true;
                 })
@@ -108,7 +108,7 @@ final class AccessTokenManagerTest extends TestCase
             $mock->shouldReceive('get')
                 ->once()
                 ->withArgs(function (string $key): bool {
-                    static::assertSame('logic4:access_token:'.base64_encode('publicKey companyKey user__name_(2)'), $key);
+                    static::assertSame('logic4:access_token:'.base64_encode('publicKey companyKey user__name_(2):api administration.administration-1'), $key);
 
                     return true;
                 })
@@ -130,7 +130,7 @@ final class AccessTokenManagerTest extends TestCase
             $mock->shouldReceive('has')
                 ->once()
                 ->withArgs(function (string $key): bool {
-                    static::assertSame('logic4:access_token:'.base64_encode('publicKey companyKey user__name_(2)'), $key);
+                    static::assertSame('logic4:access_token:'.base64_encode('publicKey companyKey user__name_(2):api administration.administration-1'), $key);
 
                     return true;
                 })


### PR DESCRIPTION
When working with multiple administrations the cached key will cause problems when switching. Including the makeScope function in the key generation should fix errors when switching between two or more administration.