### PR TITLE
Fix memory leak in ClientFactory

### DIFF
--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -52,8 +52,10 @@ class ClientFactory
     {
         $this->handlerStack = $handlerStack;
 
-        $this->handlerStack->push(Middleware::mapRequest(function ($request) {
-            $accessToken = $this->tokenManager->getAccessToken();
+        $tokenManager = $this->tokenManager;
+
+        $this->handlerStack->push(Middleware::mapRequest(static function ($request) use ($tokenManager) {
+            $accessToken = $tokenManager->getAccessToken();
 
             return $request->withHeader('Authorization', "Bearer {$accessToken}");
         }));


### PR DESCRIPTION
Change the access token middleware closure to static, ensuring
the client handler stack is not tied to the ClientFactory instance.

This allows the garbage collector to properly clean up the instances,
and free up memory.
