### PR TITLE
Support the new URL's but don't generate yet for v3

### DIFF
--- a/generate.php
+++ b/generate.php
@@ -14,14 +14,12 @@ $versions = Webparking\Logic4Client\Generator\Generator::resolveVersions();
 
 $refresh = in_array('--refresh', $argv ?? [], true);
 
-$setupHasRun = false;
-
-foreach ($versions as $version) {
+foreach ($versions as $version => $url) {
     echo "Generating API namespace $version...\n";
 
     $generator = new Webparking\Logic4Client\Generator\Generator();
     $generator->setRefresh($refresh);
-    $generator->generate($version);
+    $generator->generate($version, $url);
 }
 
 echo 'API classes generated at '.now()->toDateTimeString()."...\n";

--- a/generator/Generator.php
+++ b/generator/Generator.php
@@ -13,8 +13,8 @@ use Webparking\Logic4Client\Enums\PaginateType;
 
 class Generator
 {
-    public static string $swaggerUrl = 'https://api.logic4server.nl/swagger/index.js';
-    public string $remoteApi = 'https://api.logic4server.nl/swagger/%s/swagger.json';
+    public static string $scalarUrl = 'https://api.logic4server.nl/scalar/';
+    public static string $baseUrl = 'https://api.logic4server.nl/';
     public string $localApi = __DIR__.'/../logic4-api-%s.json';
 
     public string $baseDirectory = __DIR__.'/../src/';
@@ -36,28 +36,36 @@ class Generator
         }
     }
 
-    /** @return array<string> */
+    /** @return array<string, string> version => url */
     public static function resolveVersions(): array
     {
-        $contents = file_get_contents(self::$swaggerUrl);
+        $contents = file_get_contents(self::$scalarUrl);
 
         Assert::string($contents, 'Could not fetch API documentation');
 
-        preg_match('/configObject = JSON.parse\(\'(.*)\'\);/', $contents, $matches);
+        preg_match('/initialize\([^,]+,\s*\w+,\s*(\{.+\})\s*,\s*\'/s', $contents, $matches);
 
-        $versions = json_decode($matches[1], true, 512, \JSON_THROW_ON_ERROR);
+        Assert::keyExists($matches, 1, 'Could not find Scalar configuration');
 
-        Assert::keyExists($versions, 'urls', 'Could not find API versions');
+        $config = json_decode($matches[1], true, 512, \JSON_THROW_ON_ERROR);
 
-        return array_diff(
-            array_map(static fn ($version) => explode('/', $version['url'], 2)[0], $versions['urls']),
-            ['latest'],
-        );
+        Assert::keyExists($config, 'sources', 'Could not find API sources');
+
+        $versions = [];
+        foreach ($config['sources'] as $source) {
+            if (preg_match('/Version v(\d+\.\d+)/', $source['title'], $versionMatch)
+                && !str_starts_with($versionMatch[1], '3.')
+            ) {
+                $versions[$versionMatch[1]] = self::$baseUrl.$source['url'];
+            }
+        }
+
+        return $versions;
     }
 
-    public function generate(string $version): void
+    public function generate(string $version, string $remoteUrl): void
     {
-        $localFile = $this->downloadApiDocumentation($version);
+        $localFile = $this->downloadApiDocumentation($version, $remoteUrl);
 
         $openapi = Reader::readFromJsonFile($localFile, resolveReferences: false);
 
@@ -96,17 +104,16 @@ class Generator
         }
     }
 
-    public function downloadApiDocumentation(string $version): string
+    public function downloadApiDocumentation(string $version, string $remoteUrl): string
     {
         $localFile = \sprintf($this->localApi, $this->getVersion($version));
-        $remoteFile = \sprintf($this->remoteApi, $version);
 
         if ($this->refresh && is_file($localFile)) {
             unlink($localFile);
         }
 
         if (!is_file($localFile)) {
-            file_put_contents($localFile, file_get_contents($remoteFile));
+            file_put_contents($localFile, file_get_contents($remoteUrl));
         }
 
         return $localFile;

--- a/tests/Feature/GeneratorTest.php
+++ b/tests/Feature/GeneratorTest.php
@@ -15,8 +15,9 @@ final class GeneratorTest extends TestCase
 
         static::assertNotEmpty($versions);
 
-        foreach ($versions as $version) {
+        foreach ($versions as $version => $url) {
             static::assertMatchesRegularExpression('/^\d+\.\d+$/', $version);
+            static::assertStringStartsWith('https://api.logic4server.nl/openapi/', $url);
         }
     }
 }


### PR DESCRIPTION
This should enable us to keep up to date for the v1 and v2 endpoints, without generating code for v3 just yet, because some more changes are required for that.